### PR TITLE
If a group is deleted, always delete its associated OG Menus

### DIFF
--- a/og_menu.module
+++ b/og_menu.module
@@ -4,6 +4,10 @@
  * Main functions and hook implementations of the og_menu module.
  */
 
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\og\Og;
+use Drupal\og\OgGroupAudienceHelper;
+
 /**
  * Implements hook_theme().
  */
@@ -20,4 +24,19 @@ function og_menu_theme() {
     'file' => 'ogmenu_instance.page.inc',
   ];
   return $theme;
+}
+
+/**
+ * Implements hook_entity_delete().
+ */
+function og_menu_entity_delete(EntityInterface $entity) {
+  // If a group is deleted, delete its associated OG Menus.
+  if (Og::isGroup($entity->getEntityTypeId(), $entity->bundle())) {
+    $storage = \Drupal::entityTypeManager()->getStorage('ogmenu_instance');
+    $properties = [OgGroupAudienceHelper::DEFAULT_FIELD => $entity->id()];
+    /** @var \Drupal\og_menu\Entity\OgMenuInstance $instance */
+    foreach ($storage->loadByProperties($properties) as $instance) {
+      $instance->delete();
+    }
+  }
 }


### PR DESCRIPTION
Currently the OG Menus are only cleaned up if the "Delete orphans" option in OG is selected. However, the "delete orphans" option is more intended for actual group content. The OG Menus don't seem to be useful any more after the group is deleted, so it's better to always clean them up even if "Delete orphans" is not selected.

In Drupal 7 this was also the case. The "Delete orphans" option was also present in the D7 version of OG, but still in `og_menu_node_delete()` the OG Menus were forcefully deleted.
