### PR TITLE
Use the menu name as a cache tag instead of a generic catch-all name

### DIFF
--- a/src/Plugin/Block/OgMenuBlock.php
+++ b/src/Plugin/Block/OgMenuBlock.php
@@ -246,7 +246,7 @@ class OgMenuBlock extends BlockBase implements ContainerFactoryPluginInterface, 
    */
   public function getCacheTags() {
     $tags = parent::getCacheTags();
-    return Cache::mergeTags($tags, ['ogmenu_instance']);
+    return Cache::mergeTags($tags, [$this->getMenuName()]);
   }
 
   /**


### PR DESCRIPTION
I found this small fix in an old installation of OG Menu. I don't remember what I was working on but I seem to have bumped into a bug at some point.

It looks like we are always passing the cache tag `ogmenu_instance` whenever we display an `OgMenuBlock`. This is not taking the actually displayed menu into account, meaning that if ANY menu changes, ALL blocks will be invalidated. This is akin to using a flamethrower for making a crème brûlée.
