### PR TITLE
Do not create new fields during config-sync

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ php:
   - 7.0
 
 env:
-  - DRUPAL_CORE=8.1.x
   - DRUPAL_CORE=8.2.x
+  - DRUPAL_CORE=8.3.x
 
 mysql:
   database: og_menu

--- a/src/Entity/OgMenu.php
+++ b/src/Entity/OgMenu.php
@@ -65,8 +65,8 @@ class OgMenu extends ConfigEntityBundleBase implements OgMenuInterface {
   public function postSave(EntityStorageInterface $storage, $update = TRUE) {
     parent::postSave($storage, $update);
      // When the menu bundle is saved, link it to og.
-    if (!$update) {
-      Og::CreateField(OgGroupAudienceHelperInterface::DEFAULT_FIELD, 'ogmenu_instance', $this->id());
+    if (!$update && !$this->isSyncing()) {
+      Og::createField(OgGroupAudienceHelperInterface::DEFAULT_FIELD, 'ogmenu_instance', $this->id());
     }
     // Invalidate the block cache to update menu-based derivatives.
     if (\Drupal::moduleHandler()->moduleExists('block')) {

--- a/tests/modules/og_menu_test/config/install/field.field.ogmenu_instance.test.og_audience.yml
+++ b/tests/modules/og_menu_test/config/install/field.field.ogmenu_instance.test.og_audience.yml
@@ -1,4 +1,3 @@
-uuid: 884b7a4c-0f75-4fc1-9951-52186d2e1fa7
 langcode: de
 status: true
 dependencies:

--- a/tests/modules/og_menu_test/config/install/field.field.ogmenu_instance.test.og_audience.yml
+++ b/tests/modules/og_menu_test/config/install/field.field.ogmenu_instance.test.og_audience.yml
@@ -1,0 +1,26 @@
+uuid: 884b7a4c-0f75-4fc1-9951-52186d2e1fa7
+langcode: de
+status: true
+dependencies:
+  config:
+    - field.storage.ogmenu_instance.og_audience
+    - og_menu.ogmenu.test
+  module:
+    - og
+id: ogmenu_instance.test.og_audience
+field_name: og_audience
+entity_type: ogmenu_instance
+bundle: test
+label: 'Groups audience'
+description: 'OG group audience reference field.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'og:default'
+  handler_settings:
+    target_bundles:
+      group: group
+  access_override: false
+field_type: og_standard_reference

--- a/tests/modules/og_menu_test/config/install/field.storage.ogmenu_instance.og_audience.yml
+++ b/tests/modules/og_menu_test/config/install/field.storage.ogmenu_instance.og_audience.yml
@@ -1,4 +1,3 @@
-uuid: aab677c6-0009-4adb-9a8c-c5f1be4b75e7
 langcode: de
 status: true
 dependencies:

--- a/tests/modules/og_menu_test/config/install/field.storage.ogmenu_instance.og_audience.yml
+++ b/tests/modules/og_menu_test/config/install/field.storage.ogmenu_instance.og_audience.yml
@@ -1,0 +1,21 @@
+uuid: aab677c6-0009-4adb-9a8c-c5f1be4b75e7
+langcode: de
+status: true
+dependencies:
+  module:
+    - node
+    - og
+    - og_menu
+id: ogmenu_instance.og_audience
+field_name: og_audience
+entity_type: ogmenu_instance
+type: og_standard_reference
+settings:
+  target_type: node
+module: og
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/tests/modules/og_menu_test/config/install/node.type.group.yml
+++ b/tests/modules/og_menu_test/config/install/node.type.group.yml
@@ -1,0 +1,12 @@
+uuid: 66fa2b50-160f-47b5-8d04-dbe0bd74dd0b
+langcode: de
+status: true
+dependencies: {}
+third_party_settings: {}
+name: Gruppe
+type: group
+description: ''
+help: ''
+new_revision: false
+preview_mode: 0
+display_submitted: true

--- a/tests/modules/og_menu_test/config/install/og_menu.ogmenu.test.yml
+++ b/tests/modules/og_menu_test/config/install/og_menu.ogmenu.test.yml
@@ -1,4 +1,3 @@
-uuid: 63249823-ab30-447d-8098-232b4732ce2f
 langcode: de
 status: true
 dependencies: {  }

--- a/tests/modules/og_menu_test/config/install/og_menu.ogmenu.test.yml
+++ b/tests/modules/og_menu_test/config/install/og_menu.ogmenu.test.yml
@@ -1,0 +1,6 @@
+uuid: 63249823-ab30-447d-8098-232b4732ce2f
+langcode: de
+status: true
+dependencies: {  }
+id: test
+label: Test

--- a/tests/modules/og_menu_test/og_menu_test.info.yml
+++ b/tests/modules/og_menu_test/og_menu_test.info.yml
@@ -1,0 +1,6 @@
+name: 'OG menu tests'
+type: module
+description: 'Test module for og_menu'
+package: Testing
+version: VERSION
+core: 8.x

--- a/tests/src/Kernel/OgMenuConfigImport.php
+++ b/tests/src/Kernel/OgMenuConfigImport.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\Tests\og_menu\Kernel\OgMenuConfigImport.
+ */
+
+namespace Drupal\Tests\og_menu\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\og\OgGroupAudienceHelper;
+
+/**
+ * @group og_menu
+ */
+class OgMenuConfigImport extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'field',
+    'og',
+    'og_menu',
+    'system',
+    'user',
+    'node'
+  ];
+
+  public function testModuleInstallationWithDefaultConfig() {
+    \Drupal::service('module_installer')->install(['og_menu_test']);
+    $this->assertArrayHasKey(OgGroupAudienceHelper::DEFAULT_FIELD, \Drupal::service('entity_field.manager')->getFieldStorageDefinitions('ogmenu_instance'));
+  }
+
+}

--- a/tests/src/Kernel/OgMenuConfigImportTest.php
+++ b/tests/src/Kernel/OgMenuConfigImportTest.php
@@ -9,11 +9,14 @@ namespace Drupal\Tests\og_menu\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\og\OgGroupAudienceHelper;
+use Drupal\Tests\ConfigTestTrait;
 
 /**
  * @group og_menu
  */
 class OgMenuConfigImportTest extends KernelTestBase {
+
+  use ConfigTestTrait;
 
   /**
    * {@inheritdoc}
@@ -29,6 +32,30 @@ class OgMenuConfigImportTest extends KernelTestBase {
 
   public function testModuleInstallationWithDefaultConfig() {
     \Drupal::service('module_installer')->install(['og_menu_test']);
+    $this->assertArrayHasKey(OgGroupAudienceHelper::DEFAULT_FIELD, \Drupal::service('entity_field.manager')->getFieldStorageDefinitions('ogmenu_instance'));
+  }
+
+  public function testConfigImport() {
+    $active = $this->container->get('config.storage');
+    $sync = $this->container->get('config.storage.sync');
+    $this->copyConfig($active, $sync);
+
+    $src_dir = __DIR__ . '/../../modules/og_menu_test/config/install';
+    $target_dir = config_get_config_directory(CONFIG_SYNC_DIRECTORY);
+
+    $names = [
+      'field.field.ogmenu_instance.test.og_audience',
+      'field.storage.ogmenu_instance.og_audience',
+      'node.type.group',
+      'og_menu.ogmenu.test'
+    ];
+
+    foreach ($names as $name) {
+      $this->assertTrue(file_unmanaged_copy("$src_dir/$name.yml", "$target_dir/$name.yml"));
+    }
+
+    // Import the content of the sync directory.
+    $this->configImporter()->import();
     $this->assertArrayHasKey(OgGroupAudienceHelper::DEFAULT_FIELD, \Drupal::service('entity_field.manager')->getFieldStorageDefinitions('ogmenu_instance'));
   }
 

--- a/tests/src/Kernel/OgMenuConfigImportTest.php
+++ b/tests/src/Kernel/OgMenuConfigImportTest.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains \Drupal\Tests\og_menu\Kernel\OgMenuConfigImport.
+ * Contains \Drupal\Tests\og_menu\Kernel\OgMenuConfigImportTest.
  */
 
 namespace Drupal\Tests\og_menu\Kernel;
@@ -13,7 +13,7 @@ use Drupal\og\OgGroupAudienceHelper;
 /**
  * @group og_menu
  */
-class OgMenuConfigImport extends KernelTestBase {
+class OgMenuConfigImportTest extends KernelTestBase {
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
I install my site test environment with `drush si --yes my_project --config-dir=../config/sync`. The install profile is very basic and does not contain any configuration. The configuration is imported directly after installation via drush (see the previous command). The og_audience fields is missing after the first import. But it shows up after another config-import.

The field creation in OgMenu:: postSave does not play well with config import. I think is safe to skip the additional logic because config-import should contain the field anyway.
