### PR TITLE
Provide a Behat step definition to check the number of items in a menu instance

### DIFF
--- a/og_menu.behat.inc
+++ b/og_menu.behat.inc
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * @file
+ * Contains \OgMenuSubContext.
+ */
+
+use Drupal\DrupalExtension\Context\DrupalSubContextBase;
+use Drupal\DrupalExtension\Context\DrupalSubContextInterface;
+use Drupal\og_menu\Tests\Traits\OgMenuTrait;
+
+/**
+ * Behat step definitions for testing OG Menus.
+ */
+class OgMenuSubContext extends DrupalSubContextBase implements DrupalSubContextInterface {
+
+  use OgMenuTrait;
+
+  /**
+   * Checks that the given OG Menu instance has the expected number of items.
+   *
+   * @param string $menu
+   *   The name of the OG Menu instance to check.
+   * @param string $label
+   *   The group label.
+   * @param string $type
+   *   The group type, either 'collection' or 'solution'.
+   * @param int $count
+   *   The expected number of items in the menu.
+   *
+   * @Then the :menu menu of the :group group of type :type should have :count item(s)
+   */
+  public function assertMenuItemCount($menu, $label, $type, $count) {
+    $group = $this->getEntityByLabel($type, $label);
+    $menu_instance = $this->getOgMenuInstance($group->id(), $menu);
+    $tree = $this->getOgMenuTree($menu_instance);
+
+    PHPUnit_Framework_Assert::assertEquals($count, count($tree));
+  }
+
+  /**
+   * Returns the entity with the given type, bundle and label.
+   *
+   * If multiple entities have the same label then the first one is returned.
+   *
+   * @param string $entity_type
+   *   The entity type to check.
+   * @param string $label
+   *   The label to check.
+   * @param string $bundle
+   *   Optional bundle to check. If omitted, the entity can be of any bundle.
+   *
+   * @return \Drupal\Core\Entity\EntityInterface
+   *   The requested entity.
+   *
+   * @throws \Exception
+   *   Thrown when an entity with the given type, label and bundle does not
+   *   exist.
+   */
+  protected function getEntityByLabel($entity_type, $label, $bundle = NULL) {
+    $entity_manager = \Drupal::entityTypeManager();
+    $storage = $entity_manager->getStorage($entity_type);
+    $entity = $entity_manager->getDefinition($entity_type);
+
+    $query = $storage->getQuery()
+      ->condition($entity->getKey('label'), $label)
+      ->range(0, 1);
+
+    // Optionally filter by bundle.
+    if ($bundle) {
+      $query->condition($entity->getKey('bundle'), $bundle);
+    }
+
+    $result = $query->execute();
+
+    if ($result) {
+      $result = reset($result);
+      return $storage->load($result);
+    }
+
+    throw new \Exception("The entity with label '$label' was not found.");
+  }
+
+}

--- a/src/Tests/Traits/OgMenuTrait.php
+++ b/src/Tests/Traits/OgMenuTrait.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Drupal\og_menu\Tests\Traits;
+
+use Drupal\menu_link_content\Entity\MenuLinkContent;
+use Drupal\og\OgGroupAudienceHelperInterface;
+use Drupal\og_menu\Entity\OgMenuInstance;
+use Drupal\og_menu\OgMenuInstanceInterface;
+
+/**
+ * Helper methods to use in OG Menu tests.
+ */
+trait OgMenuTrait {
+
+  /**
+   * Retrieves an OG Menu instance from the database.
+   *
+   * @param string $group_id
+   *   The group id of the parent entity.
+   * @param string $type
+   *   The OG Menu bundle.
+   *
+   * @return \Drupal\og_menu\OgMenuInstanceInterface|null
+   *    The menu instance as retrieved from the database, or NULL if no instance
+   *    is found.
+   */
+  protected function getOgMenuInstance($group_id, $type) {
+    $values = [
+      'type' => $type,
+      OgGroupAudienceHelperInterface::DEFAULT_FIELD => $group_id,
+    ];
+
+    $instances = \Drupal::entityTypeManager()->getStorage('ogmenu_instance')->loadByProperties($values);
+
+    return !empty($instances) ? array_pop($instances) : NULL;
+  }
+
+  /**
+   * Created an OG Menu instance for a given group.
+   *
+   * @param string $group_id
+   *    The id of the group that this menu will belong to.
+   * @param string $type
+   *   The OG Menu bundle.
+   *
+   * @return \Drupal\Core\Entity\EntityInterface
+   *    The newly created menu instance.
+   *
+   * @throws \Exception
+   *    If the saving was unsuccessful.
+   */
+  protected function createOgMenuInstance($group_id, $type) {
+    $values = [
+      'type' => $type,
+      OgGroupAudienceHelperInterface::DEFAULT_FIELD => $group_id,
+    ];
+
+    $og_menu_instance = OgMenuInstance::create($values);
+    $og_menu_instance->save();
+    if ($og_menu_instance->id()) {
+      return $og_menu_instance;
+    }
+    throw new \Exception('Unable to save menu instance.');
+  }
+
+  /**
+   * Creates a menu link.
+   *
+   * Used to create menu links for og menu instances.
+   * The $item data is an array ready to be passed to the
+   * MenuLinkContent::create method.
+   *
+   * @code
+   *
+   * $item_data = [
+   *  'title' => 'My label for the menu',
+   *  'link' => [
+   *     'uri' => '/path/of/menu/item',
+   *   ],
+   *   'menu_name' => menu_machine_name,
+   *   'weight' => 1,
+   *   'expanded' => TRUE,
+   * ];
+   *
+   * @end_code
+   *
+   * @param array $item_data
+   *    The item data.
+   *
+   * @see \Drupal\menu_link_content\Entity\MenuLinkContent::create()
+   */
+  protected function createOgMenuItem(array $item_data) {
+    $menu_link = MenuLinkContent::create($item_data);
+    $menu_link->save();
+  }
+
+}


### PR DESCRIPTION
It would be nice to have some Behat step definitions provided for common tasks so that people can easily get up and running with testing their OG Menu implementations in their projects.

Here is an initial step definition that checks the number of menu items that are present in a given OG Menu instance.
