### PR TITLE
Remove uid from OgMenuInstance entity_keys

### DIFF
--- a/src/Entity/OgMenuInstance.php
+++ b/src/Entity/OgMenuInstance.php
@@ -41,7 +41,6 @@ use Drupal\og_menu\OgMenuInstanceInterface;
  *     "id" = "id",
  *     "bundle" = "type",
  *     "uuid" = "uuid",
- *     "uid" = "user_id",
  *     "langcode" = "langcode",
  *   },
  *   links = {


### PR DESCRIPTION
OgMenuInstance defines uid entity_keys but it is not used

We should either delete the key `uid` or add the user id field.

Since Drupal core doesn't care about what user created a menu, I suggest we remove it.