### PR TITLE
Let ContentEntityBase create entity_keys

### DIFF
--- a/src/Entity/OgMenuInstance.php
+++ b/src/Entity/OgMenuInstance.php
@@ -66,28 +66,13 @@ class OgMenuInstance extends ContentEntityBase implements OgMenuInstanceInterfac
    * {@inheritdoc}
    */
   public static function baseFieldDefinitions(EntityTypeInterface $entity_type) {
-    $fields['id'] = BaseFieldDefinition::create('integer')
-      ->setLabel(t('ID'))
-      ->setDescription(t('The ID of the OG Menu instance entity.'))
-      ->setReadOnly(TRUE);
+    $fields = parent::baseFieldDefinitions($entity_type);
+
     $fields['type'] = BaseFieldDefinition::create('entity_reference')
       ->setLabel(t('Type'))
       ->setDescription(t('The OG Menu'))
       ->setSetting('target_type', 'ogmenu')
       ->setRequired(TRUE);
-    $fields['uuid'] = BaseFieldDefinition::create('uuid')
-      ->setLabel(t('UUID'))
-      ->setDescription(t('The UUID of the OG Menu instance entity.'))
-      ->setReadOnly(TRUE);
-    $fields['langcode'] = BaseFieldDefinition::create('language')
-      ->setLabel(t('Language code'))
-      ->setDescription(t('The language code for the OG Menu instance entity.'))
-      ->setDisplayOptions('form', array(
-        'type' => 'language_select',
-        'weight' => 10,
-      ))
-      ->setDisplayConfigurable('form', TRUE);
-
 
     return $fields;
   }


### PR DESCRIPTION
ContentEntityBase::baseFieldDefinitions can create fields for keys like id, uuid, langcode.