### PR TITLE
Update Travis for use with latest php & drupal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: php
 sudo: false
 
 php:
-  - 7.0
   - 7.1
   - 7.2
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,11 @@ language: php
 sudo: false
 
 php:
-  - 5.5
-  - 5.6
-  - 7.0
+  - 7.2
 
 env:
-  - DRUPAL_CORE=8.2.x
-  - DRUPAL_CORE=8.3.x
+  - DRUPAL_CORE=8.7.x
+  - DRUPAL_CORE=8.8.x
 
 mysql:
   database: og_menu

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,13 @@ language: php
 sudo: false
 
 php:
+  - 7.0
+  - 7.1
   - 7.2
 
 env:
+  - DRUPAL_CORE=8.6.x
   - DRUPAL_CORE=8.7.x
-  - DRUPAL_CORE=8.8.x
 
 mysql:
   database: og_menu


### PR DESCRIPTION
- PHP 5 is deprecated, test from 7.0 on;
- Test Drupal 8.6 & 8.7;